### PR TITLE
[PKG-2345] aom 3.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - cmake
     - perl
     - nasm      # [x86_64]
+    # we need binutils for the `as` executable
     - binutils  # [aarch64]
     - make      # [unix]
     - patch     # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - perl
-    - nasm
+    - nasm      # [x86_64]
     - make      # [unix]
     - patch     # [not win]
     - m2-patch  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - cmake
     - perl
     - nasm      # [x86_64]
+    - binutils  # [aarch64]
     - make      # [unix]
     - patch     # [not win]
     - m2-patch  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,8 +24,9 @@ requirements:
     - cmake
     - perl
     - nasm
-    - make   # [unix]
-
+    - make      # [unix]
+    - patch     # [not win]
+    - m2-patch  # [win]
 test:
   commands:
     - aomenc --help  # [build_platform == target_platform]
@@ -47,6 +48,7 @@ about:
     AOMedia Video 1 (AV1), is an open, royalty-free video coding format designed for
     video transmissions over the Internet.
   dev_url: https://aomedia.googlesource.com/aom/
+  doc_url: https://aomedia.googlesource.com/aom/
 extra:
   recipe-maintainers:
     - matthiasdiener


### PR DESCRIPTION
[PKG-2345] aom 3.6.0

- fork from `conda-forge`: https://github.com/conda-forge/aom-feedstock/blob/main/recipe/meta.yaml
- upstream: https://aomedia.googlesource.com/aom/
- linter
- [include nasm only for x86_64](https://github.com/AnacondaRecipes/aom-feedstock/pull/1/commits/0289e56ebdd5d13a16613388ae866fc8ee2d4129)
- [use binutils for aarch64](https://github.com/AnacondaRecipes/aom-feedstock/pull/1/commits/43a5de3407245d79b504f7bd330a906cda3b89cc) because we need it for the `as` executable (the asm)

[PKG-2345]: https://anaconda.atlassian.net/browse/PKG-2345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ